### PR TITLE
Remove redundant monster stats labels

### DIFF
--- a/script-v2.js
+++ b/script-v2.js
@@ -879,7 +879,6 @@ class HabitTracker {
             const totalCount = this.calculateTotalAll(habit.id);
             const level = this.getMonsterLevel(totalCount);
             const monsterType = this.getMonsterType(totalCount);
-            const bestStreak = this.getBestStreak(habit.id);
 
             const monsterCard = document.createElement('div');
             monsterCard.className = 'monster-card';
@@ -891,10 +890,6 @@ class HabitTracker {
                 <div class="monster-name">${habit.shortName}</div>
                 <div class="monster-level">Lv.${level}</div>
                 <div class="monster-description">${monsterType.name}</div>
-                <div class="monster-stats">
-                    <span>合計: ${totalCount}</span>
-                    <span>最高: ${bestStreak}日</span>
-                </div>
             `;
 
             monsterGrid.appendChild(monsterCard);

--- a/script.js
+++ b/script.js
@@ -999,8 +999,6 @@ class HabitTracker {
             const totalCount = this.calculateTotalAll(habit.id);
             const level = this.getMonsterLevel(totalCount);
             const monsterType = this.getMonsterType(totalCount);
-            const bestStreak = this.getBestStreak(habit.id);
-
             const monsterCard = document.createElement('div');
             monsterCard.className = 'monster-card';
 
@@ -1016,8 +1014,6 @@ class HabitTracker {
                 <div class="monster-level">Lv.${level}</div>
                 <div class="monster-description">${monsterType.name}</div>
                 <div class="monster-stats">
-                    <span>合計: ${totalCount}</span>
-                    <span>最高: ${bestStreak}日</span>
                     <span>次のレベルまで: ${daysToNext}日</span>
                 </div>
             `;


### PR DESCRIPTION
## Summary
- remove the total and best streak labels from the monster cards
- adjust both script versions to drop unused data fetching

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3aa1254448322bcbe8257dcb84fa6