### PR TITLE
Add achievement total currency display

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,10 @@
                 <!-- モチベーション表示 -->
                 <div class="motivation-section">
                     <h3>🏆 あなたの成果</h3>
+                    <div class="achievement-total">
+                        <span class="total-label">成果合計</span>
+                        <span class="total-value" id="achievementTotal">0ギル</span>
+                    </div>
                     <div class="motivation-stats">
                         <div class="stat-card">
                             <div class="stat-icon">🔥</div>

--- a/script.js
+++ b/script.js
@@ -1489,6 +1489,9 @@ class HabitTracker {
         document.getElementById('totalScore').textContent = this.totalScore;
         document.getElementById('perfectDays').textContent = this.achievements.perfectDays;
         document.getElementById('badgeCount').textContent = this.achievements.badges.length;
+
+        const totalAchievementValue = this.calculateAchievementTotal();
+        document.getElementById('achievementTotal').textContent = `${totalAchievementValue}ギル`;
     }
 
     // 全達成データを再計算
@@ -1551,8 +1554,18 @@ class HabitTracker {
         if (achievements.perfectDays >= 10) achievements.badges.push('完璧10日');
         if (achievements.perfectDays >= 50) achievements.badges.push('完璧50日');
         if (achievements.perfectDays >= 100) achievements.badges.push('完璧100日');
-        
+
         return achievements;
+    }
+
+    calculateAchievementTotal() {
+        const achievements = this.achievements || {};
+        const currentStreak = Math.max(0, achievements.currentStreak || 0);
+        const perfectDays = Math.max(0, achievements.perfectDays || 0);
+        const badgeCount = Array.isArray(achievements.badges) ? achievements.badges.length : 0;
+        const totalScore = Math.max(0, this.totalScore || 0);
+
+        return currentStreak + perfectDays + badgeCount + totalScore;
     }
 
     showMonsterView() {

--- a/styles.css
+++ b/styles.css
@@ -1970,6 +1970,26 @@ body {
     text-shadow: 0 2px 4px rgba(0,0,0,0.3);
 }
 
+.achievement-total {
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 20px;
+    color: #f1c40f;
+    font-weight: 700;
+}
+
+.achievement-total .total-label {
+    font-size: 16px;
+    letter-spacing: 0.08em;
+}
+
+.achievement-total .total-value {
+    font-size: 28px;
+    text-shadow: 0 2px 6px rgba(0,0,0,0.4);
+}
+
 .motivation-stats {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));


### PR DESCRIPTION
## Summary
- show an overall achievement total in the motivation section
- calculate the total from streaks, perfect days, badges, and score and format it as ギル
- style the new achievement total display for emphasis

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3d231e7d0832293cce230644744bc