### PR TITLE
Adjust badge grid layout for consistent two-column display

### DIFF
--- a/script.js
+++ b/script.js
@@ -2072,7 +2072,7 @@ class HabitTracker {
 
         board.innerHTML = '';
 
-        BADGE_LIBRARY.forEach((category, index) => {
+        BADGE_LIBRARY.forEach(category => {
             const categoryCard = document.createElement('div');
             categoryCard.className = 'badge-category-card';
 
@@ -2118,7 +2118,7 @@ class HabitTracker {
 
             const grid = document.createElement('div');
             grid.className = 'badge-card-grid';
-            const shouldUseTwoColumn = index === 0 || index >= 2;
+            const shouldUseTwoColumn = (category.badges || []).length >= 4;
             if (shouldUseTwoColumn) {
                 grid.classList.add('two-column-grid');
             }

--- a/styles.css
+++ b/styles.css
@@ -2522,17 +2522,44 @@ body {
 
 .badge-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
     gap: 14px;
 }
 
 .badge-card-grid.two-column-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 600px) {
+    .badge-card-grid {
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+
     .badge-card-grid.two-column-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .badge-card {
+        padding: 14px;
+        min-height: 150px;
+    }
+
+    .badge-card-body {
+        gap: 10px;
+    }
+
+    .badge-icon {
+        font-size: 26px;
+    }
+
+    .badge-name {
+        font-size: 14px;
+    }
+
+    .badge-condition {
+        font-size: 11px;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure badge categories with multiple entries use the enforced two-column grid so the score badges align correctly on desktop
- update badge grid styling and responsive tweaks to keep two-column layouts on mobile while refining spacing and typography

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d504e70e608322bae5617958f07b0c