### PR TITLE
Fix badge layout on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2290,10 +2290,11 @@ body {
 }
 
 .badge-progress-overview {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     gap: 16px;
     margin-bottom: 22px;
+    align-items: stretch;
 }
 
 .badge-owned-section {
@@ -2371,6 +2372,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    height: 100%;
 }
 
 .badge-progress-card.highlight {
@@ -2527,7 +2529,7 @@ body {
 }
 
 .badge-card-grid.two-column-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 16px;
 }
 
@@ -2537,6 +2539,11 @@ body {
     }
 
     .badge-card-grid.two-column-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+    }
+
+    .badge-progress-overview {
         grid-template-columns: repeat(2, minmax(0, 1fr));
         gap: 12px;
     }


### PR DESCRIPTION
## Summary
- switch the badge overview cards to a responsive grid so two cards sit side by side on small screens
- allow badge cards to stretch vertically and adjust the two-column badge grid to better fit narrow viewports
- ensure the badge overview keeps a two-column layout on phones for a consistent appearance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d50b190b5c8322a814b22ce06a5906