### PR TITLE
Adjust badge card height on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2537,7 +2537,6 @@ body {
 
     .badge-card {
         padding: 10px;
-        min-height: 110px;
     }
 
     .badge-card-body {
@@ -2772,7 +2771,7 @@ body {
     }
 
     .badge-card {
-        min-height: 160px;
+        min-height: 120px;
     }
 
     .badge-owned-grid {
@@ -2787,6 +2786,12 @@ body {
 
     .badge-owned-icon {
         font-size: 22px;
+    }
+}
+
+@media (max-width: 600px) {
+    .badge-card {
+        min-height: 110px;
     }
 }
 /* アプリ情報のスタイル */

--- a/styles_web.css
+++ b/styles_web.css
@@ -2536,8 +2536,7 @@ body {
     }
 
     .badge-card {
-        padding: 14px;
-        min-height: 150px;
+        padding: 10px;
     }
 
     .badge-card-body {
@@ -2756,7 +2755,7 @@ body {
     }
 
     .badge-card {
-        min-height: 160px;
+        min-height: 120px;
     }
 
     .badge-owned-grid {
@@ -2771,6 +2770,12 @@ body {
 
     .badge-owned-icon {
         font-size: 22px;
+    }
+}
+
+@media (max-width: 600px) {
+    .badge-card {
+        min-height: 110px;
     }
 }
 /* アプリ情報のスタイル */


### PR DESCRIPTION
## Summary
- reduce the badge card min-height applied at the 768px breakpoint so mobile cards match the other badge lists
- add an explicit mobile override to keep the 110px min-height on narrow screens for consistent sizing

## Testing
- Manual: Viewed the badge screen in a mobile viewport


------
https://chatgpt.com/codex/tasks/task_e_68d75123309c8322afedd62ea72b958c