### PR TITLE
Improve report chart empty state

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,8 +195,11 @@
                             <h3>合計値の推移</h3>
                             <div class="chart-summary" id="totalChartSummary"></div>
                         </div>
-                        <div class="chart-container">
+                        <div class="chart-container" id="totalChartContainer">
                             <canvas id="totalChart"></canvas>
+                            <div class="chart-empty-message" id="totalChartEmptyMessage">
+                                まだ表示できるデータがありません
+                            </div>
                         </div>
                         <div class="chart-footer" id="totalChartFooter"></div>
                     </div>

--- a/script.js
+++ b/script.js
@@ -1239,12 +1239,45 @@ class HabitTracker {
         if (!canvas) return;
 
         const chartData = this.getTotalChartData();
+        this.updateTotalChartSummary(chartData);
+
+        const container = document.getElementById('totalChartContainer');
+        const emptyMessage = document.getElementById('totalChartEmptyMessage');
         const ctx = canvas.getContext('2d');
-        if (!ctx) return;
+
+        const setEmptyState = (isEmpty, message) => {
+            if (emptyMessage && typeof message === 'string') {
+                emptyMessage.textContent = message;
+            }
+            if (container) {
+                container.classList.toggle('chart-container--empty', isEmpty);
+            }
+        };
 
         if (this.totalChart) {
             this.totalChart.destroy();
+            this.totalChart = null;
         }
+
+        if (!ctx) {
+            setEmptyState(true, 'グラフを表示できません');
+            return;
+        }
+
+        if (typeof Chart === 'undefined') {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            setEmptyState(true, 'グラフを読み込めませんでした');
+            return;
+        }
+
+        const hasData = chartData.dailyValues.some(value => value > 0);
+        if (!hasData) {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            setEmptyState(true, 'まだ表示できるデータがありません');
+            return;
+        }
+
+        setEmptyState(false);
 
         const initialMin = Math.max(0, chartData.labels.length - 14);
         const initialMax = chartData.labels.length - 1;

--- a/styles.css
+++ b/styles.css
@@ -917,6 +917,34 @@ body {
     height: 100% !important;
 }
 
+.chart-empty-message {
+    display: none;
+    color: #dfe4ff;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.6;
+    padding: 0 16px;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.45);
+}
+
+.chart-container--empty {
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed rgba(154, 167, 194, 0.35);
+    background: rgba(0, 0, 0, 0.35);
+}
+
+.chart-container--empty canvas {
+    display: none;
+}
+
+.chart-container--empty .chart-empty-message {
+    display: block;
+}
+
 .chart-footer {
     margin-top: 16px;
     display: flex;


### PR DESCRIPTION
## Summary
- show a clear empty state message instead of a blank graph when no report data is available
- guard chart rendering when Chart.js is unavailable and only render when data exists
- style the chart container empty state to reduce the unused space and improve visibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d935351a7483229873125316a0c9f9