### PR TITLE
Tighten report layout and remove duplicate habit names

### DIFF
--- a/script.js
+++ b/script.js
@@ -1173,7 +1173,7 @@ class HabitTracker {
             html += `
                 <tr>
                     <td class="habit-number">${index + 1}</td>
-                    <td class="habit-name">${habit.shortName}<small>${habit.name}</small></td>
+                    <td class="habit-name">${habit.shortName}</td>
                     <td>
                         <div class="report-progress">
                             <div class="progress-row">

--- a/styles.css
+++ b/styles.css
@@ -970,7 +970,7 @@ body {
 
 /* レポートテーブルセクション */
 .report-table-section {
-    margin: 30px 0;
+    margin: 16px 0 0;
 }
 
 .report-card {
@@ -1042,7 +1042,7 @@ body {
 .report-table th {
     background: rgba(255, 255, 255, 0.06);
     color: #f5f5f5;
-    padding: 10px 12px;
+    padding: 8px 12px;
     font-size: 12px;
     font-weight: 600;
     text-align: center;
@@ -1052,7 +1052,7 @@ body {
 .report-table td {
     background: rgba(0, 0, 0, 0.55);
     color: #e7e7e7;
-    padding: 10px 12px;
+    padding: 8px 12px;
     font-size: 12px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     text-align: center;
@@ -1074,17 +1074,10 @@ body {
     color: #ffffff;
 }
 
-.report-table .habit-name small {
-    display: block;
-    color: #9aa7c2;
-    font-weight: 400;
-    margin-top: 2px;
-}
-
 .report-progress {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
 }
 
 .report-progress .progress-row {


### PR DESCRIPTION
## Summary
- remove the duplicated long habit name from the monthly report table to keep each row concise
- tighten spacing around the report table and within its cells for a denser layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d93bdf003c8322b06896002acc8b3a