### PR TITLE
Align habit report cells to top

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1056,6 +1056,7 @@ body {
     font-size: 12px;
     border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     text-align: center;
+    vertical-align: top;
 }
 
 .report-table tr:last-child td {


### PR DESCRIPTION
## Summary
- ensure report table cells align to the top so habit names no longer show unnecessary blank space beneath them

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d958de9d408322aa36b3ec2773965a